### PR TITLE
Generated more clean project

### DIFF
--- a/src/main/resources/archetype-resources/pom.xml
+++ b/src/main/resources/archetype-resources/pom.xml
@@ -79,7 +79,7 @@
             <version>${kotowari.version}</version>
         </dependency>
 
-        #if ($webServer == "undertow")
+#if ($webServer == "undertow")
         <dependency>
             <groupId>net.unit8.enkan</groupId>
             <artifactId>enkan-component-undertow</artifactId>

--- a/src/main/resources/archetype-resources/src/main/java/Main.java
+++ b/src/main/resources/archetype-resources/src/main/java/Main.java
@@ -10,7 +10,7 @@ import kotowari.system.KotowariCommandRegister;
 
 public class Main {
     public static void main(String[] args) throws Exception {
-        PseudoRepl repl = new PseudoRepl(MyExampleSystemFactory.class.getName());
+        PseudoRepl repl = new PseudoRepl(MySystemFactory.class.getName());
         ReplBoot.start(repl,
                 new ScaffoldCommandRegister(),
                 new KotowariCommandRegister(),

--- a/src/main/resources/archetype-resources/src/main/java/Main.java
+++ b/src/main/resources/archetype-resources/src/main/java/Main.java
@@ -8,9 +8,6 @@ import enkan.system.repl.pseudo.ReplClient;
 import kotowari.scaffold.command.ScaffoldCommandRegister;
 import kotowari.system.KotowariCommandRegister;
 
-/**
- * @author kawasima
- */
 public class Main {
     public static void main(String[] args) throws Exception {
         PseudoRepl repl = new PseudoRepl(MyExampleSystemFactory.class.getName());

--- a/src/main/resources/archetype-resources/src/main/java/MyApplicationFactory.java
+++ b/src/main/resources/archetype-resources/src/main/java/MyApplicationFactory.java
@@ -17,9 +17,6 @@ import ${package}.controller.IndexController;
 import static enkan.util.BeanBuilder.builder;
 import static enkan.util.Predicates.*;
 
-/**
- * @author [It's you]
- */
 public class MyApplicationFactory implements ApplicationFactory {
     @Override
     public Application create(ComponentInjector injector) {

--- a/src/main/resources/archetype-resources/src/main/java/MyExampleSystemFactory.java
+++ b/src/main/resources/archetype-resources/src/main/java/MyExampleSystemFactory.java
@@ -24,9 +24,6 @@ import enkan.component.jetty.JettyComponent;
 import static enkan.component.ComponentRelationship.component;
 import static enkan.util.BeanBuilder.builder;
 
-/**
- * @author kawasima
- */
 public class MyExampleSystemFactory implements EnkanSystemFactory {
     @Override
     public EnkanSystem create() {

--- a/src/main/resources/archetype-resources/src/main/java/MySystemFactory.java
+++ b/src/main/resources/archetype-resources/src/main/java/MySystemFactory.java
@@ -24,7 +24,7 @@ import enkan.component.jetty.JettyComponent;
 import static enkan.component.ComponentRelationship.component;
 import static enkan.util.BeanBuilder.builder;
 
-public class MyExampleSystemFactory implements EnkanSystemFactory {
+public class MySystemFactory implements EnkanSystemFactory {
     @Override
     public EnkanSystem create() {
         return EnkanSystem.of(


### PR DESCRIPTION
When I generate project by archetype, I get some unnecessary information with it.

### 1. Javadoc
I do not want enkan's author name in my project.
```
/**
 * @author kawasima
 */
```

I also want to decide if I write my name as author name or not.
```
/**
 * @author [it's you]
 */
```

### 2. MyApplicationFactory and MyExampleSystemFactory
I want these two Factory class to have same prefix.

### 3. Invalid whitespace in pom.xml
I get this pom.xml when I generate project.
```
            <version>${kotowari.scaffold.version}</version>
        </dependency>
                <dependency>
            <groupId>net.unit8.enkan</groupId>
            <artifactId>enkan-component-undertow</artifactId>
            <version>${enkan.undertow.version}</version>
        </dependency>
```